### PR TITLE
fixed deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
 		"email": "nkohari@gmail.com",
 		"web":   "http://nate.io/"
 	}],
-	"repositories": [{
+	"repository": {
 		"type": "git",
 		"url":  "http://github.com/nkohari/node-hipchat.git"
-	}],
+	},
 	"dependencies": {
 		"underscore": "1.1.7"
 	}


### PR DESCRIPTION
When installing via `npm` the following deprecation warning appeared:

``` shell
npm WARN package.json node-hipchat@0.2.0 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

No more.
